### PR TITLE
fix: handle potential undefined speechSynthesis when unsupported

### DIFF
--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -151,7 +151,7 @@ export const SettingsDialog = ({ open, onClose }: SettingsProps) => {
   // Function to get the available speech synthesis voices
   // https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis
   const getAvailableVoices = (): SpeechSynthesisVoice[] => {
-    const voices = window.speechSynthesis.getVoices();
+    const voices = window.speechSynthesis?.getVoices() ?? [];
     const voiceInfoArray: SpeechSynthesisVoice[] = [];
     for (const voice of voices) {
       voiceInfoArray.push(voice);
@@ -171,10 +171,12 @@ export const SettingsDialog = ({ open, onClose }: SettingsProps) => {
   }, []);
 
   // Ensure the voices are loaded before calling getAvailableVoices
-  window.speechSynthesis.onvoiceschanged = () => {
-    const availableVoices = getAvailableVoices();
-    setAvailableVoices(availableVoices ?? []);
-  };
+  if (window.speechSynthesis){
+    window.speechSynthesis.onvoiceschanged = () => {
+      const availableVoices = getAvailableVoices();
+      setAvailableVoices(availableVoices ?? []);
+    };
+  }
   const handleVoiceChange = (event: SelectChangeEvent<unknown>) => {
     // Handle the selected voice
     const selectedVoice = availableVoices.find(


### PR DESCRIPTION
## Problem Statement
Certain runtime environments do not support `window.speechSynthesis`, and attempting to access it directly can lead to crashes.

## Proposal
To prevent crashes, we should check for the availability of `window.speechSynthesis` before using it. By making modifications in just two specific locations, we can ensure that the rest of the code functions correctly, as other parts depend on these two functional block. If these checks make them void function, the subsequent code will not execute, thereby avoiding potential errors.